### PR TITLE
Provide hint in output when conflict targetClass and fromClass are the same

### DIFF
--- a/changelog/@unreleased/pr-14.v2.yml
+++ b/changelog/@unreleased/pr-14.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Provide hint in output when conflict targetClass and fromClass are
+    the same
+  links:
+  - https://github.com/palantir/gradle-transitive-abi-checker/pull/14

--- a/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
+++ b/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
@@ -88,13 +88,34 @@ public final class ConflictPrinter {
             }
             sb.append("\t" + dependency);
             if (knownBrokenTransitives.size() == 1) {
-                sb.append(" with " + knownBrokenTransitives.get(0));
+                String transitive = knownBrokenTransitives.get(0);
+                sb.append(" with " + transitive);
+                if (transitive.equals(dependency)) {
+                    sb.append("\n\t\t-> " + selfDependencyHint(dependency));
+                }
             } else {
-                sb.append(" with:\n");
-                knownBrokenTransitives.forEach(transitive -> sb.append("\t\t" + transitive));
+                sb.append(" with:");
+                knownBrokenTransitives.forEach(transitive -> {
+                    sb.append("\n\t\t" + transitive);
+
+                    if (transitive.equals(dependency)) {
+                        sb.append("\n\t\t\t-> " + selfDependencyHint(dependency));
+                    }
+                });
             }
+
             sb.append("\n\n");
         });
+    }
+
+    /**
+     * If we have a conflict where the target dependency is the same as the one with the break, this likely means
+     *   that e.g. a method/field in a super class was removed (there may be other cases though).
+     */
+    private static String selfDependencyHint(String dependency) {
+        return "This generally indicates a class in " + dependency
+                + " inherited from a super class from another library, which had an ABI break, "
+                + "but we cannot determine which one.";
     }
 
     /**
@@ -165,6 +186,15 @@ public final class ConflictPrinter {
             sb.append(indentPrefix + "  " + indentCharItem(isLastReason) + "- " + reason + "\n");
 
             String indentReason = indentPrefix + "  " + indentCharSubItems(isLastReason);
+
+            Conflict firstConflict = conflictsForReason.get(0);
+            if (firstConflict
+                    .dependency()
+                    .targetClass()
+                    .equals(firstConflict.dependency().fromClass())) {
+                sb.append(indentReason + "  |  * "
+                        + "It was likely coming from a super class/interface provided by another library.\n");
+            }
 
             outputCallsitesForConflictReasons(sb, indentReason, conflictsForReason);
         });

--- a/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
+++ b/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
@@ -187,6 +187,8 @@ public final class ConflictPrinter {
 
             String indentReason = indentPrefix + "  " + indentCharSubItems(isLastReason);
 
+            // Just look at the first conflict since they should all have the same target/from classes at this point.
+            // If these are the same, hint to user that it was likely due to a break in a super class/interface
             Conflict firstConflict = conflictsForReason.get(0);
             if (firstConflict
                     .dependency()

--- a/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
+++ b/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
@@ -115,7 +115,7 @@ public final class ConflictPrinter {
     private static String selfDependencyHint(String dependency) {
         return "This generally indicates a class in " + dependency
                 + " inherited from a super class from another library, which had an ABI break, "
-                + "but we cannot determine which one.";
+                + "but there is insufficient information to determine the root dependency.";
     }
 
     /**


### PR DESCRIPTION
## Before this PR
If we find an ABI break where a super method or field is missing (i.e. it was broken in the transitive the super came from), we currently raise a conflict which would output e.g.

```
ABI Incompatibilities were detected between the following libraries. You should upgrade or downgrade one for each pair. Exact conflicts are detailed below.

        com.library:1.2.3 with com.library:1.2.3

Breaks found in: com.library:1.2.3
  \- Using transitive: com.library:1.2.3
     \- In class: com.library.MyClass
<...>
        \- Method not found: void com.library.MyClass.superMethod()
           \- In void <init>() (line 123)
  ===========================
```

## After this PR
==COMMIT_MSG==
Provide hint in output when conflict targetClass and fromClass are the same
==COMMIT_MSG==

This will now output (for the same above case):
```
ABI Incompatibilities were detected between the following libraries. You should upgrade or downgrade one for each pair. Exact conflicts are detailed below.

        com.library:1.2.3 with com.library:1.2.3
                -> This generally indicates a class in com.library:1.2.3 inherited from a super class from another library, which had an ABI break, but there is insufficient information to determine the root dependency.

Breaks found in: com.library:1.2.3
  \- Using transitive: com.library:1.2.3
     \- In class: com.library.MyClass
<...>
        \- Method not found: void com.library.MyClass.superMethod()
           |  * It was likely coming from a super class/interface provided by another library.
           \- In void <init>() (line 123)
  ===========================
```


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

