### PR TITLE
[Test] Adding a method to parent interface/abstract class is not a break

### DIFF
--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
@@ -1224,6 +1224,96 @@ public class MethodConflictCheckerIntegrationTest extends BaseConflictCheckerInt
         assertNoConflicts(tempDir);
     }
 
+    @Test
+    public void adding_method_on_parent_interface_does_not_conflict() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.reachableDependency(
+                "com.MyClass",
+                // language=java
+                """
+                package com;
+                public class MyClass implements ParentInterface {
+                    public MyClass() {
+                        method();
+                    }
+
+                    public void method() {
+                        System.out.println("method called");
+                    }
+                }
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.ParentInterface",
+                // language=java
+                """
+                package com;
+                public interface ParentInterface {
+                    void method();
+                }
+                """);
+
+        sources.transitiveAfterDependency(
+                "com.ParentInterface",
+                // language=java
+                """
+                package com;
+                public interface ParentInterface {
+                    void method();
+                    void newMethod();
+                }
+                """);
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertNoConflicts(tempDir);
+    }
+
+    @Test
+    public void adding_abstract_method_on_parent_class_does_not_conflict() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.reachableDependency(
+                "com.MyClass",
+                // language=java
+                """
+                package com;
+                public class MyClass extends ParentClass {
+                    public MyClass() {
+                        method();
+                    }
+
+                    public void method() {
+                        System.out.println("method called");
+                    }
+                }
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.ParentClass",
+                // language=java
+                """
+                package com;
+                public abstract class ParentClass {
+                    abstract void method();
+                }
+                """);
+
+        sources.transitiveAfterDependency(
+                "com.ParentClass",
+                // language=java
+                """
+                package com;
+                public abstract class ParentClass {
+                    abstract void method();
+                    abstract void newMethod();
+                }
+                """);
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertNoConflicts(tempDir);
+    }
+
     private static void assertThatMethodNotFound(
             Path baseDir,
             String fromClass,


### PR DESCRIPTION
## Before this PR
Adding two tests to validate that
- adding a method to a parent interface
- adding an abstract method to a parent class
are not ABI breaks (by default - they would likely be if these were to be called on the implementation itself)

## After this PR
==COMMIT_MSG==
[Test] Adding a method to parent interface/abstract class is not a break
==COMMIT_MSG==

## Possible downsides?
It's debatable whether the checker should actually throw in these cases, because the implementation class could actually be passed as the parent interface/class, and fail at runtime when calling the new method, but we wouldn't be able to check if this is broken, since they would map to the interface's method (which exists).

Filed https://github.com/palantir/gradle-transitive-abi-checker/issues/33 to track this specific case

