### PR TITLE
[DNM / Example] Showcase jackson custom deserializers not deemed reachable

### DIFF
--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
@@ -40,6 +40,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -156,16 +157,20 @@ abstract class BaseConflictCheckerIntegrationTest {
      *   - the {@link #DEPENDENCY} directory's classes as the direct dependency
      *   - the {@link #TRANSITIVE} directory's classes as the transitive dependency, which might have conflicts
      */
-    protected static List<Conflict> checkConflicts(Path baseDir) {
-        Artifact root = loadArtifact(baseDir, ROOT);
-        Artifact dependency = loadArtifact(baseDir, DEPENDENCY);
-        Artifact transitive = loadArtifact(baseDir, TRANSITIVE);
+    protected static List<Conflict> checkConflicts(Path baseDir, Path... extraLibraries) {
+        Artifact root = loadArtifactFromBase(baseDir, ROOT);
+        Artifact dependency = loadArtifactFromBase(baseDir, DEPENDENCY);
+        Artifact transitive = loadArtifactFromBase(baseDir, TRANSITIVE);
 
         // Load the jdk as well, to get all runtime artifacts
         List<Artifact> artifacts = new ArrayList<>(getJdkArtifacts());
         artifacts.add(root);
         artifacts.add(dependency);
         artifacts.add(transitive);
+
+        artifacts.addAll(Arrays.stream(extraLibraries)
+                .map(BaseConflictCheckerIntegrationTest::loadArtifact)
+                .toList());
 
         ConflictCheckerConfiguration configuration = ConflictCheckerConfiguration.builder()
                 .addErrorArtifactPrefixes(DEPENDENCY)
@@ -212,9 +217,17 @@ abstract class BaseConflictCheckerIntegrationTest {
         Files.copy(javaFileObject.get().openInputStream(), path, StandardCopyOption.REPLACE_EXISTING);
     }
 
-    private static Artifact loadArtifact(Path baseDir, String type) {
+    private static Artifact loadArtifactFromBase(Path baseDir, String type) {
+        return loadArtifact(target(baseDir, type), type);
+    }
+
+    private static Artifact loadArtifact(Path libraryPath) {
+        return loadArtifact(libraryPath, libraryPath.toString());
+    }
+
+    private static Artifact loadArtifact(Path path, String artifactName) {
         // Use new loaders to avoid any caching between tests
-        return new ArtifactLoader().load(target(baseDir, type), ArtifactName.of(type));
+        return new ArtifactLoader().load(path, ArtifactName.of(artifactName));
     }
 
     private static List<Artifact> getJdkArtifacts() {

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ReachabilityConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ReachabilityConflictCheckerIntegrationTest.java
@@ -19,9 +19,12 @@ package com.palantir.abi.checker.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.abi.checker.datamodel.conflict.Conflict;
 import com.palantir.abi.checker.datamodel.conflict.Conflict.ConflictCategory;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -375,5 +378,80 @@ public class ReachabilityConflictCheckerIntegrationTest extends BaseConflictChec
                 .havingCause()
                 .isInstanceOf(NoClassDefFoundError.class)
                 .withMessageContaining("com/Removed");
+    }
+
+    @Test
+    public void classes_are_reachable_through_annotation() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.reachableDependency(
+                "com.Reachable",
+                // language=java
+                """
+                package com;
+                import com.fasterxml.jackson.databind.ObjectMapper;
+                import com.fasterxml.jackson.core.JsonProcessingException;
+                public class Reachable {
+                    public Reachable () {
+                        try {
+                            ObjectMapper mapper = new ObjectMapper();
+                            // This should be considered as reaching BreakingClass
+                            System.out.println(mapper.writeValueAsString(new BreakingClass()));
+                        } catch (JsonProcessingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+                """);
+
+        // This class is reachable through Reachable, itself reachable from root, so it should conflict
+        sources.unreachableDependency(
+                "com.BreakingClass",
+                // language=java
+                """
+                package com;
+
+                import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+                @JsonSerialize(using = RemovedToStringSerializer.class)
+                public class BreakingClass {
+                }
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.RemovedToStringSerializer",
+                // language=java
+                """
+                package com;
+                import com.fasterxml.jackson.databind.JsonSerializer;
+                import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+                public class RemovedToStringSerializer extends ToStringSerializer {}
+                """);
+
+        // No classes after, so it should conflict
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .isThrownBy(() -> runClassFiles(tempDir))
+                .havingCause()
+                .isInstanceOf(TypeNotPresentException.class)
+                .withMessageContaining("com.RemovedToStringSerializer");
+
+        Path jacksonDatabindPath = Path.of(ObjectMapper.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .getPath());
+        Path jacksonCorePath = Path.of(JsonProcessingException.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .getPath());
+        List<Conflict> conflicts = checkConflicts(tempDir, jacksonDatabindPath, jacksonCorePath);
+
+        assertThat(conflicts).hasSize(1);
+        Conflict conflict = conflicts.get(0);
+        assertThat(conflict.category()).isEqualTo(ConflictCategory.CLASS_NOT_FOUND);
+        assertThat(conflict.dependency().targetClass().className()).isEqualTo("com.RemovedToStringSerializer");
     }
 }


### PR DESCRIPTION
This is an example PR meant to showcase a failing test where we currently fail to determine that a custom jackson serializer ended up not being found.
Note that this is expected in the current state of things, given we don't follow reflective calls, nor analyse annotations.

