### PR TITLE
Do not inherit constructors from super classes

### DIFF
--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/graph/ClassGraph.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/graph/ClassGraph.java
@@ -25,6 +25,7 @@ import com.palantir.abi.checker.datamodel.method.DeclaredMethod;
 import com.palantir.abi.checker.datamodel.method.MethodReference;
 import com.palantir.abi.checker.datamodel.method.Reference;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
+import com.palantir.abi.checker.util.Constants;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -91,10 +92,23 @@ public final class ClassGraph {
     }
 
     public Optional<MethodReference> resolveMethodReference(DeclaredClass targetClass, MethodReference targetMethod) {
-        return resolveMember(targetClass, targetMethod, (clazz, method) -> {
+        Optional<MethodReference> methodReference = resolveMember(targetClass, targetMethod, (clazz, method) -> {
             DeclaredMethod declaredMethod = clazz.methods().get(method.method());
             return declaredMethod == null ? null : declaredMethod.reference();
         });
+
+        if (methodReference.isPresent()) {
+            MethodReference resolvedMethod = methodReference.get();
+            if (resolvedMethod.method().name().equals(Constants.INSTANCE_INIT_METHOD_NAME)
+                    && !resolvedMethod.clazz().equals(targetClass.className())) {
+                // If the method is a constructor, it can't be resolved to a different class than the one we requested
+                // See linking exceptions in
+                //   https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-6.html#jvms-6.5.invokespecial
+                return Optional.empty();
+            }
+        }
+
+        return methodReference;
     }
 
     public Optional<FieldReference> resolveFieldReference(DeclaredClass targetClass, FieldReference targetField) {

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/util/Constants.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/util/Constants.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.abi.checker.util;
+
+public final class Constants {
+    public static final String INSTANCE_INIT_METHOD_NAME = "<init>";
+    public static final String CLASS_INIT_METHOD_NAME = "<clinit>";
+
+    private Constants() {}
+}

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
@@ -119,6 +119,8 @@ public class MethodConflictCheckerIntegrationTest extends BaseConflictCheckerInt
                 """
                 package com;
                 public class ClassWithAbiBreak {
+                    // This effectively removes the default constructor, which is a binary break,
+                    //   even though the parent java.lang.Object constructor is still available
                     public ClassWithAbiBreak(boolean arg) {}
                 }
                 """);

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
@@ -90,6 +90,52 @@ public class MethodConflictCheckerIntegrationTest extends BaseConflictCheckerInt
     }
 
     @Test
+    public void removing_default_constructor_conflicts() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.reachableDependency(
+                "com.BreakingClass",
+                // language=java
+                """
+                package com;
+                public class BreakingClass {
+                    public BreakingClass() {
+                        // Calling to create an actual ABI break at runtime for the java test
+                        new ClassWithAbiBreak();
+                    }
+                }
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.ClassWithAbiBreak",
+                // language=java
+                """
+                package com;
+                public class ClassWithAbiBreak {}
+                """);
+
+        sources.transitiveAfterDependency(
+                "com.ClassWithAbiBreak",
+                // language=java
+                """
+                package com;
+                public class ClassWithAbiBreak {
+                    public ClassWithAbiBreak(boolean arg) {}
+                }
+                """);
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .isThrownBy(() -> runClassFiles(tempDir))
+                .havingCause()
+                .isInstanceOf(NoSuchMethodError.class)
+                .withMessageContaining("com.ClassWithAbiBreak: method 'void <init>()' not found");
+
+        assertThatMethodNotFound(
+                tempDir, "com.BreakingClass", voidMethod("<init>"), "com.ClassWithAbiBreak", voidMethod("<init>"));
+    }
+
+    @Test
     public void removing_method_reference_conflicts() {
         JavaFiles.Builder sources = JavaFiles.builder();
         sources.reachableDependency(


### PR DESCRIPTION
## Before this PR
https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-6.html#jvms-6.5.invokespecial explicitly states `if the resolved method is an instance initialization method, and the class in which it is declared is not the class symbolically referenced by the instruction, a NoSuchMethodError is thrown.`

So far, we were actually inheriting constructors like all other methods, which caused us to miss cases where a constructor was removed, but existed in a super class (typically, the default constructor always exists in `java.lang.Object`)

## After this PR
==COMMIT_MSG==
Do not inherit constructors from super classes
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

