### PR TITLE
Add (disabled) tests around calling unimplemented methods

### DIFF
--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
@@ -19,6 +19,7 @@ package com.palantir.abi.checker.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
@@ -85,18 +86,33 @@ abstract class BaseConflictCheckerIntegrationTest {
     protected static void generateClassFiles(Path baseDir, JavaFiles sourceFiles) {
         Compiler compiler = Compiler.javac();
 
-        Compilation compilation = compiler.compile(sourceFiles.allBeforeSources());
+        // Compile the dependency sources first, against the old transitive sources.
+        Compilation compilationDependency = compiler.compile(ImmutableSet.<JavaFileObject>builder()
+                .addAll(sourceFiles.reachableDependencySources())
+                .addAll(sourceFiles.unreachableDependencySources())
+                .addAll(sourceFiles.transitiveBeforeSources())
+                .build());
 
         // We don't copy the classes for the transitive dependency since we want to replace them with the updated ones
-        copyClassFiles(compilation, target(baseDir, DEPENDENCY), sourceFiles.reachableDependencySources());
-        copyClassFiles(compilation, target(baseDir, DEPENDENCY), sourceFiles.unreachableDependencySources());
-        copyClassFiles(compilation, target(baseDir, ROOT), sourceFiles.rootSources());
+        copyClassFiles(compilationDependency, target(baseDir, DEPENDENCY), sourceFiles.reachableDependencySources());
+        copyClassFiles(compilationDependency, target(baseDir, DEPENDENCY), sourceFiles.unreachableDependencySources());
 
+        // Then compile the transitive sources, which will be used to compile the root project.
         if (!sourceFiles.transitiveAfterSources().isEmpty()) {
-            Compilation compilation2 = compiler.compile(sourceFiles.transitiveAfterSources());
-
-            copyClassFiles(compilation2, target(baseDir, TRANSITIVE), sourceFiles.transitiveAfterSources());
+            Compilation compilationTransitive = compiler.compile(ImmutableSet.<JavaFileObject>builder()
+                    .addAll(sourceFiles.transitiveAfterSources())
+                    .build());
+            copyClassFiles(compilationTransitive, target(baseDir, TRANSITIVE), sourceFiles.transitiveAfterSources());
         }
+
+        // Finally, compile the root project
+        Compilation compilationRoot = compiler.withClasspath(List.of(
+                        target(baseDir, DEPENDENCY).toFile(),
+                        target(baseDir, TRANSITIVE).toFile()))
+                .compile(ImmutableSet.<JavaFileObject>builder()
+                        .addAll(sourceFiles.rootSources())
+                        .build());
+        copyClassFiles(compilationRoot, target(baseDir, ROOT), sourceFiles.rootSources());
     }
 
     /**

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/MethodConflictCheckerIntegrationTest.java
@@ -26,6 +26,7 @@ import com.palantir.abi.checker.datamodel.method.MethodDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -980,8 +981,7 @@ public class MethodConflictCheckerIntegrationTest extends BaseConflictCheckerInt
         assertNoConflicts(tempDir);
     }
 
-    // TODO(aldexis): Do not inherit static methods from interfaces
-    @Disabled("This isn't actually working yet")
+    @Disabled("https://github.com/palantir/gradle-transitive-abi-checker/issues/9")
     @Test
     public void inherited_static_method_call_from_interface_conflicts() {
         JavaFiles.Builder sources = JavaFiles.builder();
@@ -1360,6 +1360,136 @@ public class MethodConflictCheckerIntegrationTest extends BaseConflictCheckerInt
         generateClassFiles(tempDir, sources.build());
 
         assertNoConflicts(tempDir);
+    }
+
+    @Disabled("https://github.com/palantir/gradle-transitive-abi-checker/issues/33")
+    @Test
+    public void calling_unimplemented_interface_method_conflicts() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.rootSources(
+                Set.of(
+                        file(
+                                "com.Root",
+                                // language=java
+                                """
+                package com;
+                public class Root {
+                    public Root() {
+                        // Even though MyClass doesn't implement newMethod, it can still be instantiated
+                        // but calling newMethod will throw an AbstractMethodError
+                        interact(new MyClass());
+                    }
+
+                    private static void interact(MyInterface myInt) {
+                        // newMethod only exists in the base interface, but isn't implemented yet in the main dependency
+                        myInt.newMethod();
+                    }
+                }
+                """)));
+
+        sources.reachableDependency(
+                "com.MyClass",
+                // language=java
+                """
+                package com;
+                public class MyClass implements MyInterface {}
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.MyInterface",
+                // language=java
+                """
+                package com;
+                public interface MyInterface {}
+                """);
+
+        sources.transitiveAfterDependency(
+                "com.MyInterface",
+                // language=java
+                """
+                package com;
+                public interface MyInterface {
+                    void newMethod();
+                }
+                """);
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .isThrownBy(() -> runClassFiles(tempDir))
+                .havingCause()
+                .isInstanceOf(AbstractMethodError.class)
+                .withMessageContainingAll("com.MyInterface", "abstract void newMethod()");
+
+        assertThatMethodNotFound(
+                tempDir,
+                "com.Root",
+                voidMethod("interact", "Lcom/MyInterface;"),
+                "com.MyClass",
+                voidMethod("newMethod"));
+    }
+
+    @Disabled("https://github.com/palantir/gradle-transitive-abi-checker/issues/33")
+    @Test
+    public void calling_unimplemented_abstract_method_conflicts() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.rootSources(
+                Set.of(
+                        file(
+                                "com.Root",
+                                // language=java
+                                """
+                package com;
+                public class Root {
+                    public Root() {
+                        // Even though MyClass doesn't implement newMethod, it can still be instantiated
+                        // but calling newMethod will throw an AbstractMethodError
+                        interact(new MyClass());
+                    }
+
+                    private static void interact(Parent obj) {
+                        // newMethod only exists in the base interface, but isn't implemented yet in the main dependency
+                        obj.newMethod();
+                    }
+                }
+                """)));
+
+        sources.reachableDependency(
+                "com.MyClass",
+                // language=java
+                """
+                package com;
+                public class MyClass extends Parent {}
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.Parent",
+                // language=java
+                """
+                package com;
+                public abstract class Parent {}
+                """);
+
+        sources.transitiveAfterDependency(
+                "com.Parent",
+                // language=java
+                """
+                package com;
+                public abstract class Parent {
+                    public abstract void newMethod();
+                }
+                """);
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .isThrownBy(() -> runClassFiles(tempDir))
+                .havingCause()
+                .isInstanceOf(AbstractMethodError.class)
+                .withMessageContainingAll("com.Parent", "abstract void newMethod()");
+
+        assertThatMethodNotFound(
+                tempDir, "com.Root", voidMethod("interact", "Lcom/Parent;"), "com.MyClass", voidMethod("newMethod"));
     }
 
     private static void assertThatMethodNotFound(


### PR DESCRIPTION
## Before this PR
See https://github.com/palantir/gradle-transitive-abi-checker/issues/33 (copied below)

If an interface defines a new method (or a class defines a new abstract method), this is not an ABI break by default (see https://github.com/palantir/gradle-transitive-abi-checker/pull/32).

However, if that method then gets called and the instance happens to be on a class that did not implement the method, this will break at runtime.

As such, when an interface method or an abstract method are called, we should validate that all reachable implementations actually implement that method (or it exists in a super class or in some other way).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add (disabled) tests around calling unimplemented methods
==COMMIT_MSG==

This does not actually fix the issue, but adds tests that are currently failing and show-casing the issue.

I've had to refactor a tiny bit how we're compiling the classes in the tests, but this is now closer to the expected reality (that is, the dependency is compiled against the old transitive sources, whereas the root project is compiled with both the dependency and the new transitive as its classpath). Otherwise, in the current state of things, the root couldn't leverage the new method that exists in the new transitive dependency version

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

