### PR TITLE
Surface conflicts due to missing caught exceptions

### DIFF
--- a/abi-check-core/src/main/java/com/palantir/abi/checker/AbiCheckerClassLoader.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/AbiCheckerClassLoader.java
@@ -43,6 +43,7 @@ import com.palantir.abi.checker.datamodel.method.CallSite;
 import com.palantir.abi.checker.datamodel.method.DeclaredMethod;
 import com.palantir.abi.checker.datamodel.method.MethodDescriptor;
 import com.palantir.abi.checker.datamodel.method.MethodReference;
+import com.palantir.abi.checker.datamodel.reference.ClassReference;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
 import com.palantir.abi.checker.datamodel.types.TypeDescriptors;
 import java.io.IOException;
@@ -63,7 +64,6 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.FieldNode;
-import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InvokeDynamicInsnNode;
 import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.LineNumberNode;
@@ -167,17 +167,11 @@ public final class AbiCheckerClassLoader {
                 }
                 if (insn instanceof MethodInsnNode methodInsn) {
                     handleMethodCall(
-                            methodCalls,
-                            lineNumber,
-                            methodInsn,
-                            () -> getCaughtExceptions(method.instructions, methodInsn, method));
+                            methodCalls, lineNumber, methodInsn, () -> getCaughtExceptions(method, methodInsn));
                 }
                 if (insn instanceof FieldInsnNode fieldInsn) {
                     handleFieldAccess(
-                            fieldAccesses,
-                            lineNumber,
-                            fieldInsn,
-                            () -> getCaughtExceptions(method.instructions, fieldInsn, method));
+                            fieldAccesses, lineNumber, fieldInsn, () -> getCaughtExceptions(method, fieldInsn));
                 }
                 if (insn instanceof InvokeDynamicInsnNode dynamicInsn) {
                     handleInvokeDynamic(
@@ -185,7 +179,7 @@ public final class AbiCheckerClassLoader {
                             fieldAccesses,
                             lineNumber,
                             dynamicInsn,
-                            () -> getCaughtExceptions(method.instructions, dynamicInsn, method));
+                            () -> getCaughtExceptions(method, dynamicInsn));
                 }
                 if (insn instanceof LdcInsnNode ldcInsnNode) {
                     handleLdc(loadedClasses, ldcInsnNode);
@@ -196,10 +190,13 @@ public final class AbiCheckerClassLoader {
             }
         }
 
+        Set<CallSite<ClassReference>> allCaughtExceptions = getCaughtExceptions(method);
+
         boolean isStatic = (method.access & Opcodes.ACC_STATIC) != 0;
         MethodDescriptor methodDescriptor = MethodDescriptor.ofDescriptor(method.desc, method.name);
         final DeclaredMethod declaredMethod = DeclaredMethod.builder()
                 .reference(MethodReference.of(className, methodDescriptor, isStatic))
+                .caughtExceptions(allCaughtExceptions)
                 .methodCalls(methodCalls)
                 .fieldAccesses(fieldAccesses)
                 .build();
@@ -210,17 +207,39 @@ public final class AbiCheckerClassLoader {
         }
     }
 
-    private static Set<ClassTypeDescriptor> getCaughtExceptions(
-            final InsnList instructions, final AbstractInsnNode insn, final MethodNode method) {
+    private static Set<CallSite<ClassReference>> getCaughtExceptions(final MethodNode method) {
+        final Set<CallSite<ClassReference>> caughtExceptions = new HashSet<>();
 
-        final Set<ClassTypeDescriptor> caughtExceptions = new HashSet<>();
-        final int instructionIndex = instructions.indexOf(insn);
         for (final TryCatchBlockNode tryCatchBlockNode : method.tryCatchBlocks) {
             if (tryCatchBlockNode.type == null) {
                 continue;
             }
-            final int catchStartIndex = instructions.indexOf(tryCatchBlockNode.start);
-            final int catchEndIndex = instructions.indexOf(tryCatchBlockNode.end);
+            ClassTypeDescriptor exception = TypeDescriptors.fromClassName(tryCatchBlockNode.type);
+
+            final int labelNodeIndex = method.instructions.indexOf(tryCatchBlockNode.handler);
+            int lineNumber = 0;
+            if (labelNodeIndex + 1 < method.instructions.size()) {
+                AbstractInsnNode abstractInsnNode = method.instructions.get(labelNodeIndex + 1);
+                if (abstractInsnNode instanceof LineNumberNode lineNumberNode) {
+                    lineNumber = lineNumberNode.line;
+                }
+            }
+            caughtExceptions.add(CallSite.of(ClassReference.of(exception), lineNumber));
+        }
+
+        return caughtExceptions;
+    }
+
+    private static Set<ClassTypeDescriptor> getCaughtExceptions(final MethodNode method, final AbstractInsnNode insn) {
+
+        final Set<ClassTypeDescriptor> caughtExceptions = new HashSet<>();
+        final int instructionIndex = method.instructions.indexOf(insn);
+        for (final TryCatchBlockNode tryCatchBlockNode : method.tryCatchBlocks) {
+            if (tryCatchBlockNode.type == null) {
+                continue;
+            }
+            final int catchStartIndex = method.instructions.indexOf(tryCatchBlockNode.start);
+            final int catchEndIndex = method.instructions.indexOf(tryCatchBlockNode.end);
             if (instructionIndex > catchStartIndex && instructionIndex < catchEndIndex) {
                 caughtExceptions.add(TypeDescriptors.fromClassName(tryCatchBlockNode.type));
             }

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/ConflictChecker.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/ConflictChecker.java
@@ -164,10 +164,13 @@ public final class ConflictChecker {
                 continue;
             }
 
-            conflicts.add(Conflict.classNotFound(
-                    ClassDependency.of(method, exceptionReference, reachabilityPath),
-                    artifactName,
-                    index.sourceMappings().get(exception)));
+            final Optional<DeclaredClass> calledClass = classGraph.loadClass(exception);
+            if (calledClass.isEmpty()) {
+                conflicts.add(Conflict.classNotFound(
+                        ClassDependency.of(method, exceptionReference, reachabilityPath),
+                        artifactName,
+                        index.sourceMappings().get(exception)));
+            }
         }
 
         return conflicts;

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/ConflictChecker.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/ConflictChecker.java
@@ -36,6 +36,7 @@ import com.palantir.abi.checker.datamodel.Artifact;
 import com.palantir.abi.checker.datamodel.ArtifactName;
 import com.palantir.abi.checker.datamodel.DeclaredClass;
 import com.palantir.abi.checker.datamodel.classlocation.ClassLocation;
+import com.palantir.abi.checker.datamodel.conflict.ClassDependency;
 import com.palantir.abi.checker.datamodel.conflict.Conflict;
 import com.palantir.abi.checker.datamodel.conflict.FieldDependency;
 import com.palantir.abi.checker.datamodel.conflict.MethodDependency;
@@ -45,6 +46,7 @@ import com.palantir.abi.checker.datamodel.graph.ClassIndex;
 import com.palantir.abi.checker.datamodel.method.CallSite;
 import com.palantir.abi.checker.datamodel.method.DeclaredMethod;
 import com.palantir.abi.checker.datamodel.method.MethodReference;
+import com.palantir.abi.checker.datamodel.reference.ClassReference;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
 import com.palantir.abi.checker.util.ExceptionsChecker;
 import java.util.ArrayList;
@@ -142,10 +144,32 @@ public final class ConflictChecker {
                     .orElseThrow(() -> new IllegalStateException("Class not found: " + reachableClass));
 
             for (DeclaredMethod method : clazz.methods().values()) {
+                conflicts.addAll(checkForBrokenCaughtExceptions(owningArtifact, method, reachabilityPath));
                 conflicts.addAll(checkForBrokenMethodCalls(owningArtifact, method, reachabilityPath));
                 conflicts.addAll(checkForBrokenFieldAccess(owningArtifact, method, reachabilityPath));
             }
         }
+        return conflicts;
+    }
+
+    private List<Conflict> checkForBrokenCaughtExceptions(
+            ArtifactName artifactName, DeclaredMethod method, List<ClassTypeDescriptor> reachabilityPath) {
+        List<Conflict> conflicts = new ArrayList<>();
+
+        for (CallSite<ClassReference> exceptionReference : method.caughtExceptions()) {
+            ClassTypeDescriptor exception = exceptionReference.owner();
+
+            if (configuration.shouldIgnoreClass(exception)) {
+                // Don't register a conflict if the target class is ignored
+                continue;
+            }
+
+            conflicts.add(Conflict.classNotFound(
+                    ClassDependency.of(method, exceptionReference, reachabilityPath),
+                    artifactName,
+                    index.sourceMappings().get(exception)));
+        }
+
         return conflicts;
     }
 

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/conflict/ClassDependency.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/conflict/ClassDependency.java
@@ -30,37 +30,31 @@
  * the License.
  */
 
-package com.palantir.abi.checker.datamodel.method;
+package com.palantir.abi.checker.datamodel.conflict;
 
-import com.palantir.abi.checker.datamodel.field.FieldReference;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.abi.checker.datamodel.method.CallSite;
+import com.palantir.abi.checker.datamodel.method.DeclaredMethod;
 import com.palantir.abi.checker.datamodel.reference.ClassReference;
-import java.util.Set;
+import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
+import java.util.List;
 import org.immutables.value.Value;
 
 /**
- * Represents the details of a declared method within a class,
- *   including which methods it's calling and which fields it's accessing.
+ * Represents a dependency between a method and a class it directly references (e.g. in caught exceptions),
+ * used in Conflict when reporting problems.
  */
 @Value.Immutable
-public interface DeclaredMethod {
-    MethodReference reference();
+@JsonSerialize(as = ImmutableMethodDependency.class)
+public interface ClassDependency extends Dependency {
 
-    /**
-     * Exceptions caught by this method. These trigger NoClassDefFoundError
-     * at Class verification time if not found (i.e. even if the method itself is unused).
-     *
-     * See https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-4.html#jvms-4.9.2
-     * "Each class mentioned in a catch_type item of the exception_table array of the method's
-     * Code_attribute structure must be Throwable or a subclass of Throwable."
-     */
-    Set<CallSite<ClassReference>> caughtExceptions();
-
-    /** Calls that this method makes to other methods. */
-    Set<CallSite<MethodReference>> methodCalls();
-
-    Set<CallSite<FieldReference>> fieldAccesses();
-
-    static ImmutableDeclaredMethod.Builder builder() {
-        return ImmutableDeclaredMethod.builder();
+    static ClassDependency of(
+            DeclaredMethod method, CallSite<ClassReference> targetClass, List<ClassTypeDescriptor> reachabilityPath) {
+        return ImmutableClassDependency.builder()
+                .reachabilityPath(reachabilityPath)
+                .fromMethod(method.reference())
+                .fromLineNumber(targetClass.lineNumber())
+                .targetClass(targetClass.owner())
+                .build();
     }
 }

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/conflict/ClassDependency.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/conflict/ClassDependency.java
@@ -45,7 +45,7 @@ import org.immutables.value.Value;
  * used in Conflict when reporting problems.
  */
 @Value.Immutable
-@JsonSerialize(as = ImmutableMethodDependency.class)
+@JsonSerialize(as = ImmutableClassDependency.class)
 public interface ClassDependency extends Dependency {
 
     static ClassDependency of(

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/conflict/ClassDependency.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/conflict/ClassDependency.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,22 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/*
- * Copyright (C) 2016 - 2025 Spotify AB
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
  */
 
 package com.palantir.abi.checker.datamodel.conflict;

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/field/FieldReference.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/field/FieldReference.java
@@ -24,7 +24,8 @@ import com.palantir.abi.checker.datamodel.types.TypeDescriptor;
 /**
  * Represents a reference to a specific field in a given class.
  */
-public record FieldReference(ClassTypeDescriptor clazz, FieldDescriptor field, boolean isStatic) implements MemberReference {
+public record FieldReference(ClassTypeDescriptor clazz, FieldDescriptor field, boolean isStatic)
+        implements MemberReference {
 
     public TypeDescriptor type() {
         return field.type();

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/field/FieldReference.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/field/FieldReference.java
@@ -17,14 +17,14 @@
 package com.palantir.abi.checker.datamodel.field;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.abi.checker.datamodel.method.Reference;
+import com.palantir.abi.checker.datamodel.reference.MemberReference;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
 import com.palantir.abi.checker.datamodel.types.TypeDescriptor;
 
 /**
  * Represents a reference to a specific field in a given class.
  */
-public record FieldReference(ClassTypeDescriptor clazz, FieldDescriptor field, boolean isStatic) implements Reference {
+public record FieldReference(ClassTypeDescriptor clazz, FieldDescriptor field, boolean isStatic) implements MemberReference {
 
     public TypeDescriptor type() {
         return field.type();

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/graph/ClassGraph.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/graph/ClassGraph.java
@@ -23,7 +23,7 @@ import com.palantir.abi.checker.datamodel.field.FieldReference;
 import com.palantir.abi.checker.datamodel.method.CallSite;
 import com.palantir.abi.checker.datamodel.method.DeclaredMethod;
 import com.palantir.abi.checker.datamodel.method.MethodReference;
-import com.palantir.abi.checker.datamodel.method.Reference;
+import com.palantir.abi.checker.datamodel.reference.MemberReference;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
 import com.palantir.abi.checker.util.Constants;
 import java.util.ArrayDeque;
@@ -121,7 +121,7 @@ public final class ClassGraph {
      * Resolves a class's member (method or field) to its actual class' reference, by walking up the class hierarchy as
      *   needed.
      */
-    private <T extends Reference> Optional<T> resolveMember(
+    private <T extends MemberReference> Optional<T> resolveMember(
             DeclaredClass targetClass, T targetMember, BiFunction<DeclaredClass, T, T> memberResolver) {
         // Note that the member here might actually have a different class than the original target from
         final T member = memberResolver.apply(targetClass, targetMember);
@@ -204,7 +204,11 @@ public final class ClassGraph {
 
             enqueueKnownClasses.accept(declaredClass.loadedClasses().stream());
 
-            // TODO(aldexis): what about method return type / parameters? caught exceptions? declared fields?
+            // TODO(aldexis): what about method return type / parameters? declared fields? Direct class reference?
+            enqueueKnownClasses.accept(declaredClass.methods().values().stream()
+                    .flatMap(declaredMethod -> declaredMethod.caughtExceptions().stream())
+                    .map(CallSite::owner));
+
             enqueueKnownClasses.accept(declaredClass.methods().values().stream()
                     .flatMap(declaredMethod -> declaredMethod.methodCalls().stream())
                     .map(CallSite::owner));

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/method/CallSite.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/method/CallSite.java
@@ -16,7 +16,10 @@
 
 package com.palantir.abi.checker.datamodel.method;
 
+import com.palantir.abi.checker.datamodel.reference.MemberReference;
+import com.palantir.abi.checker.datamodel.reference.Reference;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -31,7 +34,11 @@ public record CallSite<T extends Reference>(T reference, int lineNumber, Set<Cla
         return reference.clazz();
     }
 
-    public static <T extends Reference> CallSite<T> of(
+    public static <T extends Reference> CallSite<T> of(T reference, int lineNumber) {
+        return new CallSite<>(reference, lineNumber, Collections.emptySet());
+    }
+
+    public static <T extends MemberReference> CallSite<T> of(
             T reference, int lineNumber, Set<ClassTypeDescriptor> caughtExceptions) {
         return new CallSite<>(reference, lineNumber, caughtExceptions);
     }

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/method/MethodReference.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/method/MethodReference.java
@@ -17,13 +17,14 @@
 package com.palantir.abi.checker.datamodel.method;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.abi.checker.datamodel.reference.MemberReference;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
 
 /**
  * Represents a reference to a specific method in a given class.
  */
 public record MethodReference(ClassTypeDescriptor clazz, MethodDescriptor method, boolean isStatic)
-        implements Reference {
+        implements MemberReference {
 
     public String pretty() {
         return method.returnType() + " " + clazz + "." + method.prettyWithoutReturnType();

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/reference/ClassReference.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/reference/ClassReference.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.abi.checker.datamodel.reference;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
+
+public record ClassReference(ClassTypeDescriptor clazz) implements Reference {
+    public String pretty() {
+        return clazz.toString();
+    }
+
+    @JsonValue
+    public String json() {
+        return pretty();
+    }
+
+    public static ClassReference of(ClassTypeDescriptor clazz) {
+        return new ClassReference(clazz);
+    }
+}

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/reference/MemberReference.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/reference/MemberReference.java
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.abi.checker.datamodel.reference;
+
+public interface MemberReference extends Reference {
+    boolean isStatic();
+}

--- a/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/reference/Reference.java
+++ b/abi-check-core/src/main/java/com/palantir/abi/checker/datamodel/reference/Reference.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package com.palantir.abi.checker.datamodel.method;
+package com.palantir.abi.checker.datamodel.reference;
 
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
 
 public interface Reference {
     ClassTypeDescriptor clazz();
-
-    boolean isStatic();
 }

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
@@ -27,6 +27,7 @@ import com.palantir.abi.checker.AbiCheckerClassLoader;
 import com.palantir.abi.checker.ArtifactLoader;
 import com.palantir.abi.checker.ConflictChecker;
 import com.palantir.abi.checker.ConflictCheckerConfiguration;
+import com.palantir.abi.checker.ImmutableConflictCheckerConfiguration;
 import com.palantir.abi.checker.JdkModuleLoader;
 import com.palantir.abi.checker.datamodel.Artifact;
 import com.palantir.abi.checker.datamodel.ArtifactName;
@@ -167,6 +168,10 @@ abstract class BaseConflictCheckerIntegrationTest {
         }
     }
 
+    protected static ImmutableConflictCheckerConfiguration.Builder config() {
+        return ConflictCheckerConfiguration.builder().addErrorArtifactPrefixes(DEPENDENCY);
+    }
+
     /**
      * Checks for conflicts for classes previously generated in baseDir by calling {@link #generateClassFiles}.
      *
@@ -176,6 +181,12 @@ abstract class BaseConflictCheckerIntegrationTest {
      *   - the {@link #TRANSITIVE} directory's classes as the transitive dependency, which might have conflicts
      */
     protected static List<Conflict> checkConflicts(Path baseDir) {
+        ConflictCheckerConfiguration configuration = config().build();
+
+        return checkConflicts(baseDir, configuration);
+    }
+
+    protected static List<Conflict> checkConflicts(Path baseDir, ConflictCheckerConfiguration configuration) {
         Artifact root = loadArtifact(baseDir, ROOT);
         Artifact dependency = loadArtifact(baseDir, DEPENDENCY);
         Artifact transitive = loadArtifact(baseDir, TRANSITIVE);
@@ -185,10 +196,6 @@ abstract class BaseConflictCheckerIntegrationTest {
         artifacts.add(root);
         artifacts.add(dependency);
         artifacts.add(transitive);
-
-        ConflictCheckerConfiguration configuration = ConflictCheckerConfiguration.builder()
-                .addErrorArtifactPrefixes(DEPENDENCY)
-                .build();
 
         // Use new loaders to avoid any caching between tests
         return ConflictChecker.checkWithEntryPoints(

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/BaseConflictCheckerIntegrationTest.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.StandardLocation;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
 abstract class BaseConflictCheckerIntegrationTest {
@@ -63,7 +64,7 @@ abstract class BaseConflictCheckerIntegrationTest {
      * If you want to manually inspect the class files, you can remove the TempDir annotation and set it to e.g.
      *   Paths.get("build/tmp/abi-checker-test").
      */
-    @TempDir
+    @TempDir(cleanup = CleanupMode.ON_SUCCESS)
     public Path tempDir;
 
     protected static JavaFileObject file(String className, String source) {
@@ -84,6 +85,8 @@ abstract class BaseConflictCheckerIntegrationTest {
      * The class files will be copied in the provided directory, each under their respective subdirectory.
      */
     protected static void generateClassFiles(Path baseDir, JavaFiles sourceFiles) {
+        System.out.println("Generating class files to " + baseDir);
+
         Compiler compiler = Compiler.javac();
 
         // Compile the dependency sources first, against the old transitive sources.

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ClassConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ClassConflictCheckerIntegrationTest.java
@@ -75,47 +75,6 @@ public class ClassConflictCheckerIntegrationTest extends BaseConflictCheckerInte
     }
 
     @Test
-    public void try_catch_can_ignore_conflict() {
-        JavaFiles.Builder sources = JavaFiles.builder();
-        sources.reachableDependency(
-                "com.BreakingClass",
-                // language=java
-                """
-                package com;
-                public class BreakingClass {
-                    public ClassWithAbiBreak field;
-                    public BreakingClass() {
-                        try {
-                            field = new ClassWithAbiBreak();
-                        } catch (NoClassDefFoundError e) {
-                            // ignore
-                        }
-                    }
-                }
-                """);
-
-        sources.transitiveBeforeDependency(
-                "com.ClassWithAbiBreak",
-                // language=java
-                """
-                package com;
-                public class ClassWithAbiBreak {}
-                """);
-
-        sources.transitiveAfterDependency(
-                "com.RenamedClassWithAbiBreak",
-                // language=java
-                """
-                package com;
-                public class RenamedClassWithAbiBreak {}
-                """);
-
-        generateClassFiles(tempDir, sources.build());
-
-        assertNoConflicts(tempDir);
-    }
-
-    @Test
     public void renaming_super_class_creates_conflicts() {
         JavaFiles.Builder sources = JavaFiles.builder();
         sources.reachableDependency(
@@ -193,7 +152,7 @@ public class ClassConflictCheckerIntegrationTest extends BaseConflictCheckerInte
     }
 
     @Test
-    public void renaming_caught_exception_creates_conflicts() {
+    public void removed_caught_exception_creates_conflicts() {
         JavaFiles.Builder sources = JavaFiles.builder();
         sources.reachableDependency(
                 "com.BreakingClass",

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ClassConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ClassConflictCheckerIntegrationTest.java
@@ -19,10 +19,13 @@ package com.palantir.abi.checker.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import com.palantir.abi.checker.ConflictCheckerConfiguration;
 import com.palantir.abi.checker.datamodel.conflict.Conflict;
 import com.palantir.abi.checker.datamodel.conflict.Conflict.ConflictCategory;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -166,6 +169,82 @@ public class ClassConflictCheckerIntegrationTest extends BaseConflictCheckerInte
                             System.out.println("test");
                         } catch (RemovedException e) {
                             // ignore
+                        } catch (KeptException e) {
+                            // ignore
+                        } catch (RemovedException2 e) {
+                            // ignore
+                        }
+                    }
+                }
+                """);
+
+        sources.transitiveDependency(
+                "com.KeptException",
+                // language=java
+                """
+                package com;
+                public class KeptException extends RuntimeException {}
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.RemovedException",
+                // language=java
+                """
+                package com;
+                public class RemovedException extends RuntimeException {}
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.RemovedException2",
+                // language=java
+                """
+                package com;
+                public class RemovedException2 extends RuntimeException {}
+                """);
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .isThrownBy(() -> runClassFiles(tempDir))
+                .havingCause()
+                .isInstanceOf(NoClassDefFoundError.class)
+                .withMessageContaining("com/RemovedException");
+
+        // Sort conflicts by target class name, to avoid flakes
+        List<Conflict> conflicts = checkConflicts(tempDir).stream()
+                .sorted(Comparator.comparing(c -> c.dependency().targetClass().className()))
+                .collect(Collectors.toList());
+
+        assertThat(conflicts).hasSize(2);
+
+        Conflict conflict = conflicts.get(0);
+        assertThat(conflict.category()).isEqualTo(ConflictCategory.CLASS_NOT_FOUND);
+        assertThat(conflict.dependency().targetClass().className()).isEqualTo("com.RemovedException");
+        // Verify the line number matches the one from the source code
+        assertThat(conflict.dependency().fromLineNumber()).isEqualTo(7);
+
+        Conflict conflict2 = conflicts.get(1);
+        assertThat(conflict2.category()).isEqualTo(ConflictCategory.CLASS_NOT_FOUND);
+        assertThat(conflict2.dependency().targetClass().className()).isEqualTo("com.RemovedException2");
+        // Verify the line number matches the one from the source code
+        assertThat(conflict2.dependency().fromLineNumber()).isEqualTo(11);
+    }
+
+    @Test
+    public void removed_caught_exception_creates_no_conflict_if_ignored() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.reachableDependency(
+                "com.BreakingClass",
+                // language=java
+                """
+                package com;
+                public class BreakingClass {
+                    public void method() {
+                        try {
+                            // This statement is purely here to avoid the entire block being removed by the compiler
+                            System.out.println("test");
+                        } catch (RemovedException e) {
+                            // ignore
                         }
                     }
                 }
@@ -187,13 +266,11 @@ public class ClassConflictCheckerIntegrationTest extends BaseConflictCheckerInte
                 .isInstanceOf(NoClassDefFoundError.class)
                 .withMessageContaining("com/RemovedException");
 
-        List<Conflict> conflicts = checkConflicts(tempDir);
+        ConflictCheckerConfiguration configuration =
+                config().addIgnoredClassPrefixes("com.RemovedException").build();
 
-        assertThat(conflicts).hasSize(1);
-        Conflict conflict = conflicts.get(0);
-        assertThat(conflict.category()).isEqualTo(ConflictCategory.CLASS_NOT_FOUND);
-        assertThat(conflict.dependency().targetClass().className()).isEqualTo("com.RemovedException");
-        // Verify the line number matches the one from the source code
-        assertThat(conflict.dependency().fromLineNumber()).isEqualTo(7);
+        List<Conflict> conflicts = checkConflicts(tempDir, configuration);
+
+        assertThat(conflicts).hasSize(0);
     }
 }

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ClassConflictCheckerIntegrationTest.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/ClassConflictCheckerIntegrationTest.java
@@ -191,4 +191,50 @@ public class ClassConflictCheckerIntegrationTest extends BaseConflictCheckerInte
 
         assertNoConflicts(tempDir);
     }
+
+    @Test
+    public void renaming_caught_exception_creates_conflicts() {
+        JavaFiles.Builder sources = JavaFiles.builder();
+        sources.reachableDependency(
+                "com.BreakingClass",
+                // language=java
+                """
+                package com;
+                public class BreakingClass {
+                    public void method() {
+                        try {
+                            // This statement is purely here to avoid the entire block being removed by the compiler
+                            System.out.println("test");
+                        } catch (RemovedException e) {
+                            // ignore
+                        }
+                    }
+                }
+                """);
+
+        sources.transitiveBeforeDependency(
+                "com.RemovedException",
+                // language=java
+                """
+                package com;
+                public class RemovedException extends RuntimeException {}
+                """);
+
+        generateClassFiles(tempDir, sources.build());
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .isThrownBy(() -> runClassFiles(tempDir))
+                .havingCause()
+                .isInstanceOf(NoClassDefFoundError.class)
+                .withMessageContaining("com/RemovedException");
+
+        List<Conflict> conflicts = checkConflicts(tempDir);
+
+        assertThat(conflicts).hasSize(1);
+        Conflict conflict = conflicts.get(0);
+        assertThat(conflict.category()).isEqualTo(ConflictCategory.CLASS_NOT_FOUND);
+        assertThat(conflict.dependency().targetClass().className()).isEqualTo("com.RemovedException");
+        // Verify the line number matches the one from the source code
+        assertThat(conflict.dependency().fromLineNumber()).isEqualTo(7);
+    }
 }

--- a/abi-check-core/src/test/java/com/palantir/abi/checker/integration/JavaFiles.java
+++ b/abi-check-core/src/test/java/com/palantir/abi/checker/integration/JavaFiles.java
@@ -117,6 +117,10 @@ interface JavaFiles {
             return addAllUnreachableDependencySources(Set.of(reachableDependencySources));
         }
 
+        Builder transitiveDependency(String className, String source) {
+            return transitiveBeforeDependency(className, source).transitiveAfterDependency(className, source);
+        }
+
         Builder transitiveBeforeDependency(String className, String source) {
             return addAllTransitiveBeforeDependencies(file(className, source));
         }


### PR DESCRIPTION
## Before this PR
When a class is being loaded, it goes through a [verification step](https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-4.html#jvms-4.10), which validates the class is structured properly.

Among [other things](https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-4.html#jvms-4.9.2), it will attempt to load (though not necessarily verify) all of the caught exceptions:
```
Each class mentioned in a catch_type item of the exception_table array of the method's Code_attribute structure must be Throwable or a subclass of Throwable.
```

We are currently not checking the exceptions caught within a method actually exist.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Surface conflicts due to missing caught exceptions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

