### PR TITLE
Improve summary output for unknown classes

### DIFF
--- a/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
+++ b/gradle-transitive-abi-checker/src/main/java/com/palantir/gradle/abi/checker/ConflictPrinter.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.abi.checker;
 
-import com.google.common.collect.Maps;
 import com.palantir.abi.checker.datamodel.conflict.Conflict;
 import com.palantir.abi.checker.datamodel.types.ClassTypeDescriptor;
 import java.util.Collection;
@@ -67,20 +66,27 @@ public final class ConflictPrinter {
         sb.append("ABI Incompatibilities were detected between the following libraries. ");
         sb.append("You should upgrade or downgrade one for each pair. Exact conflicts are detailed below.\n\n");
 
-        final SortedMap<String, List<String>> incompatibleDependencies = Maps.transformValues(
-                byBrokenDependency,
-                conflicts -> conflicts.stream()
-                        .map(c -> c.existsIn().name())
-                        .distinct()
-                        .toList());
+        byBrokenDependency.forEach((dependency, conflicts) -> {
+            List<String> missingClassesInUnknownDep = conflicts.stream()
+                    .filter(c -> c.existsIn().name().equals(Conflict.UNKNOWN_ARTIFACT_NAME_STRING))
+                    .map(c -> c.dependency().targetClass().toString())
+                    .distinct()
+                    .sorted()
+                    .toList();
 
-        incompatibleDependencies.forEach((dependency, brokenTransitives) -> {
-            if (brokenTransitives.contains(Conflict.UNKNOWN_ARTIFACT_NAME_STRING)) {
+            if (!missingClassesInUnknownDep.isEmpty()) {
                 sb.append("\t" + dependency + " refers to unknown classes, "
                         + "so we couldn't determine the transitive library that broke its ABI.\n");
+                for (String clazz : missingClassesInUnknownDep) {
+                    sb.append("\t\t" + clazz + "\n");
+                }
             }
-            List<String> knownBrokenTransitives = brokenTransitives.stream()
-                    .filter(brokenTransitive -> !brokenTransitive.equals(Conflict.UNKNOWN_ARTIFACT_NAME_STRING))
+
+            List<String> knownBrokenTransitives = conflicts.stream()
+                    .map(c -> c.existsIn().name())
+                    .distinct()
+                    .filter(name -> !name.equals(Conflict.UNKNOWN_ARTIFACT_NAME_STRING))
+                    .sorted()
                     .toList();
 
             if (knownBrokenTransitives.isEmpty()) {


### PR DESCRIPTION
## Before this PR
When debugging issues caused by unknown classes being referenced, it is a bit annoying to parse the detailed output to figure out which classes may be missing, when we can easily surface the list of missing classes, which often are enough to identify the library that is causing problems.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Improve summary output for unknown classes
==COMMIT_MSG==

This now adds the list of missing classes directly in the summary, e.g. 
```
ABI Incompatibilities were detected between the following libraries. You should upgrade or downgrade one for each pair. Exact conflicts are detailed below.

        org.apache.maven:maven-model-builder:3.8.9 refers to unknown classes, so we couldn't determine the transitive library that broke its ABI.
                org.codehaus.plexus.util.xml.XmlStreamReader
                org.codehaus.plexus.util.xml.Xpp3Dom
                org.codehaus.plexus.util.xml.pull.XmlPullParserException

        org.apache.maven:maven-model:3.8.9 refers to unknown classes, so we couldn't determine the transitive library that broke its ABI.
                org.codehaus.plexus.util.xml.Xpp3Dom
                org.codehaus.plexus.util.xml.Xpp3DomBuilder
                org.codehaus.plexus.util.xml.pull.EntityReplacementMap
                org.codehaus.plexus.util.xml.pull.MXParser
                org.codehaus.plexus.util.xml.pull.XmlPullParser
                org.codehaus.plexus.util.xml.pull.XmlPullParserException

        org.apache.maven:maven-repository-metadata:3.8.9 refers to unknown classes, so we couldn't determine the transitive library that broke its ABI.
                org.codehaus.plexus.util.xml.pull.EntityReplacementMap
                org.codehaus.plexus.util.xml.pull.MXParser
                org.codehaus.plexus.util.xml.pull.MXSerializer
                org.codehaus.plexus.util.xml.pull.XmlPullParser
                org.codehaus.plexus.util.xml.pull.XmlPullParserException
                org.codehaus.plexus.util.xml.pull.XmlSerializer

        org.apache.maven:maven-resolver-provider:3.8.9 refers to unknown classes, so we couldn't determine the transitive library that broke its ABI.
                org.codehaus.plexus.util.xml.pull.XmlPullParserException
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

